### PR TITLE
fixed small typo in Edit/Editor menu

### DIFF
--- a/src/sublimeless_zk.py
+++ b/src/sublimeless_zk.py
@@ -183,7 +183,7 @@ class Sublimeless_Zk(QObject):
         self.toggleWrapMarkersAction = QAction('Toggle Wrap Markers', self)
         self.toggleWrapIndentAction = QAction('Toggle Wrap Indent', self)
         self.toggleAutoIndentAction = QAction('Toggle Auto-Indent')
-        self.toggleIndentationGuidesAction = QAction('Toggle Indentation Guiedes', self)
+        self.toggleIndentationGuidesAction = QAction('Toggle Indentation Guides', self)
         self.toggleUseTabsAction = QAction('Toggle TABs / Spaces', self)
 
         # Recent folders actions


### PR DESCRIPTION
There was a small typo in the Edit/Editor/Toggle Indentation Guides menu item.